### PR TITLE
Only the first matched source is deleted

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,13 @@ function RemoveSourceWebpackPlugin(para) {
 RemoveSourceWebpackPlugin.prototype.apply = function(compiler) {
   const remover = (compilation, callback) => {
     const keys = Object.keys(compilation.assets);
+
     this.regexList.forEach(regex => {
-      const source = keys.find(key => regex.test(key));
-      if (source) delete compilation.assets[source];
+      keys.forEach(key => {
+        if (regex.test(key)) delete compilation.assets[key];
+      });
     });
+
     if (callback) callback();
   };
 


### PR DESCRIPTION
Hello!
Seems, I faced with bug.

For example, I have config with regex `/chunk.*.js/`.

And project has files:
- `chunk.ca296d55.js`
- `chunk.ca296d55.js.gz`
- `chunk.ca296d55.js.map`
- `chunk.ca296d55.js.map.gz`

Now, only `chunk.ca296d55.js` will be deleted.

I added some changes to fix it.